### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/io/fastq/package-info.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/io/fastq/package-info.java
@@ -45,12 +45,12 @@
  *
  * <p>
  * 
- * <a href="http://dx.doi.org/10.1093/nar/gkp1137">The Sanger FASTQ file format for sequences
+ * <a href="https://doi.org/10.1093/nar/gkp1137">The Sanger FASTQ file format for sequences
  * with quality scores, and the Solexa/Illumina FASTQ variants</a>
  * <p>
  * Peter J. A. Cock (Biopython), Christopher J. Fields (BioPerl), Naohisa Goto (BioRuby),
  * Michael L. Heuer (BioJava) and Peter M. Rice (EMBOSS).<br>
- * Nucleic Acids Research, <a href="http://dx.doi.org/10.1093/nar/gkp1137">doi:10.1093/nar/gkp1137</a>
+ * Nucleic Acids Research, <a href="https://doi.org/10.1093/nar/gkp1137">doi:10.1093/nar/gkp1137</a>
  *
  * <p>
  * Moved from org.biojava.nbio.sequencing (biojava-sequencing module) in 5.0.0

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/SuperPositionQCP.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/SuperPositionQCP.java
@@ -77,15 +77,15 @@ import org.slf4j.LoggerFactory;
  * Liu P, Agrafiotis DK, & Theobald DL (2011) Reply to comment on: "Fast
  * determination of the optimal rotation matrix for macromolecular
  * superpositions." Journal of Computational Chemistry 32(1):185-186.
- * [http://dx.doi.org/10.1002/jcc.21606]
+ * [https://doi.org/10.1002/jcc.21606]
  * <p>
  * Liu P, Agrafiotis DK, & Theobald DL (2010) "Fast determination of the optimal
  * rotation matrix for macromolecular superpositions." Journal of Computational
- * Chemistry 31(7):1561-1563. [http://dx.doi.org/10.1002/jcc.21439]
+ * Chemistry 31(7):1561-1563. [https://doi.org/10.1002/jcc.21439]
  * <p>
  * Douglas L Theobald (2005) "Rapid calculation of RMSDs using a
  * quaternion-based characteristic polynomial." Acta Crystallogr A
- * 61(4):478-480. [http://dx.doi.org/10.1107/S0108767305015266 ]
+ * 61(4):478-480. [https://doi.org/10.1107/S0108767305015266 ]
  * <p>
  * This is an adoption of the original C code QCProt 1.4 (2012, October 10) to
  * Java. The original C source code is available from

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/UnitQuaternions.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/UnitQuaternions.java
@@ -87,7 +87,7 @@ public class UnitQuaternions {
 	 * <p>
 	 * The formula is taken from: Huynh, D. Q. (2009). Metrics for 3D rotations:
 	 * comparison and analysis. Journal of Mathematical Imaging and Vision,
-	 * 35(2), 155–164. http://doi.org/10.1007/s10851-009-0161-2
+	 * 35(2), 155–164. https://doi.org/10.1007/s10851-009-0161-2
 	 * 
 	 * @param q1
 	 *            quaternion as Quat4d object


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all static DOI links accordingly.

Cheers!